### PR TITLE
Add configure/make check step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y cmake g++ make file
+      - name: Configure
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+      - name: Build
+        run: cmake --build build -j$(nproc)
+      - name: Test
+        run: |
+          cd build
+          ctest --output-on-failure
+      - name: Configure (Autotools)
+        run: |
+          mkdir autobuild
+          cd autobuild
+          ../configure
+      - name: Make
+        run: |
+          cd autobuild
+          make -j$(nproc)
+      - name: Make check
+        run: |
+          cd autobuild
+          make check
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,89 @@
+cmake_minimum_required(VERSION 3.10)
+project(tblis LANGUAGES C CXX)
+
+find_package(Threads REQUIRED)
+
+set(CMAKE_C_STANDARD 99)
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+
+# Generate configuration headers for minimal build
+set(INCLUDE_CONFIGS "#include \"configs/reference/config.hpp\"")
+set(FOREACH_CONFIG "FOREACH_CONFIG(reference_config)")
+set(FOREACH_CONFIG_AND_TYPE "#define FOREACH_TYPE(type) \\\nFOREACH_CONFIG_AND_TYPE(type, reference_config)\n#include \"foreach_type.h\"")
+set(FOREACH_TYPE "FOREACH_TYPE(float)\nFOREACH_TYPE(double)\nFOREACH_TYPE(scomplex)\nFOREACH_TYPE(dcomplex)")
+configure_file(src/configs/include_configs.hpp.in src/configs/include_configs.hpp @ONLY)
+configure_file(src/configs/foreach_config.h.in src/configs/foreach_config.h @ONLY)
+configure_file(src/configs/foreach_config_and_type.h.in src/configs/foreach_config_and_type.h @ONLY)
+configure_file(src/configs/foreach_type.h.in src/configs/foreach_type.h @ONLY)
+
+# Create a header directory that mimics the installed layout
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/include)
+file(CREATE_LINK ${CMAKE_CURRENT_SOURCE_DIR}/src ${CMAKE_BINARY_DIR}/include/tblis SYMBOLIC)
+
+add_subdirectory(src/external/tci)
+
+file(GLOB_RECURSE TBLIS_SRC
+    src/iface/*.cxx
+    src/internal/*.cxx
+    src/configs/configs.cxx
+    src/configs/reference/*.cxx
+    src/util/*.cxx
+    src/kernels/*.cxx
+    src/matrix/*.cxx
+)
+
+add_library(tblis ${TBLIS_SRC})
+
+# include directories
+target_include_directories(tblis PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/external/marray/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/external/stl_ext/include>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/external/catch>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/external/tci>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/external/tci>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/src/configs>
+    $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/include>
+)
+
+target_link_libraries(tblis PUBLIC tci Threads::Threads atomic)
+
+# Tests
+enable_testing()
+add_executable(tblis_example test/test_install.cxx)
+target_include_directories(tblis_example PRIVATE
+    ${CMAKE_BINARY_DIR}/include
+)
+target_link_libraries(tblis_example PRIVATE tblis)
+add_test(NAME tblis_example COMMAND tblis_example)
+
+# Build and register each test file as its own executable
+file(GLOB TEST_FILES
+    test/1t/*.cxx
+    test/3m/*.cxx
+    test/3t/*.cxx
+)
+set(TEST_SUPPORT test/test.cxx)
+foreach(src ${TEST_FILES})
+    get_filename_component(name_we ${src} NAME_WE)
+    get_filename_component(dir ${src} DIRECTORY)
+    get_filename_component(dir_name ${dir} NAME)
+    set(test_name "${dir_name}_${name_we}")
+    add_executable(${test_name} ${TEST_SUPPORT} ${src})
+    target_include_directories(${test_name} PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/external/catch
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/external/marray/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/external/stl_ext/include
+        ${CMAKE_CURRENT_SOURCE_DIR}/src/external/tci
+        ${CMAKE_CURRENT_BINARY_DIR}/src/external/tci
+        ${CMAKE_CURRENT_SOURCE_DIR}/src
+        ${CMAKE_CURRENT_BINARY_DIR}/src/configs
+        ${CMAKE_BINARY_DIR}/include
+    )
+    target_link_libraries(${test_name} PRIVATE tblis)
+    add_test(NAME ${test_name} COMMAND ${test_name})
+endforeach()
+

--- a/src/external/tci/CMakeLists.txt
+++ b/src/external/tci/CMakeLists.txt
@@ -1,0 +1,110 @@
+cmake_minimum_required(VERSION 3.10)
+
+include(CheckIncludeFile)
+include(CheckSymbolExists)
+include(CheckCSourceCompiles)
+
+# Default to disabled for all mutex/barrier/thread options
+set(USE_PTHREAD_MUTEX 0)
+set(USE_PTHREAD_SPINLOCK 0)
+set(USE_OSX_SPINLOCK 0)
+set(USE_OMP_LOCK 0)
+set(USE_ATOMIC_SPINLOCK 0)
+
+set(USE_PTHREAD_BARRIER 0)
+set(USE_SPIN_BARRIER 0)
+
+set(USE_PTHREADS_THREADS 0)
+set(USE_OPENMP_THREADS 0)
+set(USE_TBB_THREADS 0)
+set(USE_PPL_THREADS 0)
+set(USE_OMPTASK_THREADS 0)
+set(USE_DISPATCH_THREADS 0)
+set(USE_WINDOWS_THREADS 0)
+
+# Detect pthread support
+find_package(Threads)
+if(Threads_FOUND)
+    set(USE_PTHREADS_THREADS 1)
+    set(CMAKE_REQUIRED_LIBRARIES ${CMAKE_REQUIRED_LIBRARIES} ${CMAKE_THREAD_LIBS_INIT})
+    check_symbol_exists(pthread_mutex_init pthread.h HAVE_PTHREAD_MUTEX)
+    if(HAVE_PTHREAD_MUTEX)
+        set(USE_PTHREAD_MUTEX 1)
+    endif()
+    check_symbol_exists(pthread_spin_init pthread.h HAVE_PTHREAD_SPIN)
+    if(HAVE_PTHREAD_SPIN)
+        set(USE_PTHREAD_SPINLOCK 1)
+    endif()
+    check_symbol_exists(pthread_barrier_init pthread.h HAVE_PTHREAD_BARRIER)
+    if(HAVE_PTHREAD_BARRIER)
+        set(USE_PTHREAD_BARRIER 1)
+    endif()
+endif()
+
+# Detect OpenMP
+find_package(OpenMP)
+if(OpenMP_C_FOUND)
+    set(USE_OPENMP_THREADS 1)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")
+    list(APPEND EXTRA_LIBS OpenMP::OpenMP_C)
+endif()
+
+# Detect libdispatch (Apple GCD)
+check_include_file(dispatch/dispatch.h HAVE_DISPATCH_H)
+find_library(DISPATCH_LIB dispatch)
+if(HAVE_DISPATCH_H AND DISPATCH_LIB)
+    set(USE_DISPATCH_THREADS 1)
+    list(APPEND EXTRA_LIBS ${DISPATCH_LIB})
+endif()
+
+# Detect TBB
+find_package(TBB QUIET)
+if(TBB_FOUND)
+    set(USE_TBB_THREADS 1)
+    list(APPEND EXTRA_LIBS TBB::tbb)
+endif()
+
+# Windows or PPL (only if building with MSVC)
+if(WIN32)
+    set(USE_WINDOWS_THREADS 1)
+endif()
+
+# Verify availability of GCC style __atomic builtins
+check_c_source_compiles(
+"#include <stdint.h>\nint main(void){int a=0;int cmp=0;return __atomic_compare_exchange_n(&a,&cmp,1,0,5,5)?0:1;}" HAVE_GCC_ATOMICS)
+if(NOT HAVE_GCC_ATOMICS)
+    message(FATAL_ERROR "__atomic builtins required")
+endif()
+
+# Use atomic spinlock if nothing else
+if(NOT USE_PTHREAD_MUTEX AND NOT USE_PTHREAD_SPINLOCK AND
+   NOT USE_OSX_SPINLOCK AND NOT USE_OMP_LOCK)
+    set(USE_ATOMIC_SPINLOCK 1)
+endif()
+
+# Use spin barrier if no pthread barrier
+if(NOT USE_PTHREAD_BARRIER)
+    set(USE_SPIN_BARRIER 1)
+endif()
+
+configure_file(tci/tci_config.h.in ${CMAKE_CURRENT_BINARY_DIR}/tci/tci_config.h @ONLY)
+
+add_library(tci
+    tci/barrier.c
+    tci/context.c
+    tci/mutex.c
+    tci/parallel.c
+    tci/slot.c
+    tci/work_item.c
+    tci/communicator.c
+    tci/task_set.c
+)
+
+target_include_directories(tci PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_CURRENT_SOURCE_DIR}/tci
+    ${CMAKE_CURRENT_BINARY_DIR}/tci
+)
+
+target_link_libraries(tci PUBLIC Threads::Threads ${EXTRA_LIBS})
+

--- a/src/tblis_config.h
+++ b/src/tblis_config.h
@@ -1,0 +1,17 @@
+#ifndef _TBLIS_CONFIG_H_
+#define _TBLIS_CONFIG_H_
+
+#include <stddef.h>
+
+#define TBLIS_LEN_TYPE ptrdiff_t
+#define TBLIS_STRIDE_TYPE ptrdiff_t
+#define TBLIS_LABEL_TYPE char
+
+#if defined(__GNUC__)
+#define TBLIS_RESTRICT __restrict__
+#else
+#define TBLIS_RESTRICT restrict
+#endif
+
+#endif
+


### PR DESCRIPTION
## Summary
- extend CI workflow to install make and file utilities
- run `configure`, `make`, and `make check` after the CMake tests

## Testing
- `cmake ..`
- `cmake --build . -j$(nproc)`
- `ctest --output-on-failure` *(interrupted)*
- `../configure` *(ran with warnings)*
- `make -j$(nproc)` *(interrupted)*

------
https://chatgpt.com/codex/tasks/task_b_685305d5fffc832a848873869ea61671