### PR TITLE
Fix CI autotools test step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,8 @@ jobs:
         run: |
           cd autobuild
           make -j$(nproc)
-      - name: Make check
+      - name: Run tests (Autotools)
         run: |
           cd autobuild
-          make check
+          ./bin/test || (echo "Test executable failed" && exit 1)
 


### PR DESCRIPTION
## Summary
- run the autotools test executable instead of calling `make check`

## Testing
- `pre-commit` *(fails: not found)*


------
https://chatgpt.com/codex/tasks/task_b_6855948dc384832abce87086ff1fbe51